### PR TITLE
ddo/Feat/Group-Data-Logic

### DIFF
--- a/api/firebase.ts
+++ b/api/firebase.ts
@@ -62,30 +62,123 @@ export const getReadingsForDate = async (date: string): Promise<Reading[]> => {
 };
 
 /**
- * Fetches all readings for a specific month and year.
- * @param year The full year (e.g., 2025).
- * @param month The month, 0-indexed (e.g., 5 for June).
+ * Finds all groups that a user is a member of.
+ * @param userId The UID of the user.
+ * @returns A promise that resolves to an array of group objects.
+ */
+export const getGroupsForUser = async (userId: string) => {
+    if (!userId) return [];
+    try {
+        const groupsCol = collection(db, 'groups');
+        // Use 'array-contains' to query for the user's ID within the mateIds array
+        const q = query(groupsCol, where('mateIds', 'array-contains', userId));
+        const querySnapshot = await getDocs(q);
+
+        const groups: any[] = [];
+        querySnapshot.forEach(doc => {
+            groups.push({ id: doc.id, ...doc.data() });
+        });
+        return groups;
+
+    } catch (error) {
+        console.error("Error fetching groups for user: ", error);
+        return [];
+    }
+}
+
+/**
+ * Fetches the profiles of all mates in a given group.
+ * @param groupId The ID of the group document.
+ * @returns A promise that resolves to an array of Mate objects.
+ */
+export const getGroupMates = async (groupId: string): Promise<Mate[]> => {
+    if (!groupId) return [];
+    try {
+        const groupRef = doc(db, 'groups', groupId);
+        const groupSnap = await getDoc(groupRef);
+
+        if (!groupSnap.exists()) {
+            console.log('No such group!');
+            return [];
+        }
+
+        const mateIds = groupSnap.data().mateIds || [];
+        if (mateIds.length === 0) return [];
+
+        const usersCol = collection(db, 'users');
+        const q = query(usersCol, where('__name__', 'in', mateIds));
+        const usersSnap = await getDocs(q);
+
+        const mates: Mate[] = [];
+        usersSnap.forEach(doc => {
+            mates.push({ id: doc.id, ...doc.data() } as Mate);
+        });
+        return mates;
+
+    } catch (error) {
+        console.error("Error fetching group mates: ", error);
+        return [];
+    }
+}
+
+/**
+ * Fetches all readings for a list of users within a specific month.
+ * @param userIds An array of user IDs.
+ * @param year The full year.
+ * @param month The month (0-indexed).
  * @returns A promise that resolves to an array of Reading objects.
  */
-export const getReadingsForMonth = async (year: number, month: number): Promise<Reading[]> => {
-  try {
-    // Calculate the start and end dates for the month
-    const startDate = new Date(year, month, 1).toISOString().slice(0, 10);
-    const endDate = new Date(year, month + 1, 0).toISOString().slice(0, 10);
+export const getReadingsForMatesByMonth = async (userIds: string[], year: number, month: number): Promise<Reading[]> => {
+    if (userIds.length === 0) return [];
+    try {
+        const startDate = new Date(year, month, 1).toISOString().slice(0, 10);
+        const endDate = new Date(year, month + 1, 0).toISOString().slice(0, 10);
 
-    const readingsCol = collection(db, 'readings');
-    // Create a query to get all documents where the 'date' is within the month
-    const q = query(readingsCol, where('date', '>=', startDate), where('date', '<=', endDate));
-    const querySnapshot = await getDocs(q);
+        const readingsCol = collection(db, 'readings');
+        const q = query(
+            readingsCol,
+            where('userId', 'in', userIds),
+            where('date', '>=', startDate),
+            where('date', '<=', endDate)
+        );
 
-    const readings: Reading[] = [];
-    querySnapshot.forEach((doc) => {
-      readings.push({ id: doc.id, ...doc.data() } as Reading);
-    });
+        const querySnapshot = await getDocs(q);
+        const readings: Reading[] = [];
+        querySnapshot.forEach(doc => {
+            readings.push({ id: doc.id, ...doc.data() } as Reading);
+        });
+        return readings;
 
-    return readings;
-  } catch (error) {
-    console.error('Error fetching readings for month:', error);
-    return [];
-  }
-};
+    } catch (error) {
+        console.error('Error fetching readings for mates:', error);
+        return [];
+    }
+}
+
+/**
+ * Fetches all readings for a list of users on a specific day.
+ * @param userIds An array of user IDs.
+ * @param date The date string in 'YYYY-MM-DD' format.
+ * @returns A promise that resolves to an array of Reading objects.
+ */
+export const getReadingsForMatesByDate = async (userIds: string[], date: string): Promise<Reading[]> => {
+    if (userIds.length === 0) return [];
+    try {
+        const readingsCol = collection(db, 'readings');
+        // Query for readings from the specific users on the specific date.
+        const q = query(
+            readingsCol,
+            where('userId', 'in', userIds),
+            where('date', '==', date)
+        );
+        const querySnapshot = await getDocs(q);
+        const readings: Reading[] = [];
+        querySnapshot.forEach(doc => {
+            readings.push({ id: doc.id, ...doc.data() } as Reading);
+        });
+        return readings;
+    } catch (error) {
+        console.error('Error fetching readings for mates on date:', error);
+        return [];
+    }
+}


### PR DESCRIPTION
## Changes
### Features / Major Changes
- Implemented Group-Aware Data Loading:
  - The app now fetches data based on the logged-in user's group membership. Users in one group will no longer see readings from users in a different group.
  - The main calendar (MonthView) and the DayView now correctly display data only from the user's specific group.
- Enhanced Firebase API Layer:
  - Added a new getGroupsForUser function to api/firebase.ts to find which group(s) a user is a part of by querying the groups collection.
  - Added a getReadingsForMatesByMonth function to efficiently fetch all readings for a list of user IDs within a specific month.
  - Added a getReadingsForMatesByDate function for fetching group-specific readings on the Day View screen.
- Updated Data Flow in Main Screens:
  - The useEffect hooks in both app/index.tsx and app/day/[date].tsx have been refactored to use the new group-based fetching logic.
  - The app now follows a clean data flow: first find the user's group, then find the mates in that group, then fetch the readings for those mates.